### PR TITLE
Add a details box plugin

### DIFF
--- a/_plugins/details_tag.rb
+++ b/_plugins/details_tag.rb
@@ -1,0 +1,27 @@
+# _plugins/details_tag.rb
+# http://movb.de/jekyll-details-support.html
+
+module Jekyll
+    module Tags
+      class DetailsTag < Liquid::Block
+
+        def initialize(tag_name, markup, tokens)
+          super
+          @caption = markup
+        end
+
+        def render(context)
+          site = context.registers[:site]
+          converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+          # below Jekyll 3.x use this:
+          # converter = site.getConverterImpl(::Jekyll::Converters::Markdown)
+          caption = converter.convert(@caption).gsub(/<\/?p[^>]*>/, '').chomp
+          body = converter.convert(super(context))
+          "<details><summary>#{caption}</summary>#{body}</details>"
+        end
+
+      end
+    end
+  end
+
+  Liquid::Template.register_tag('details', Jekyll::Tags::DetailsTag)

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -201,3 +201,11 @@ h1 {
         margin-left: 1cm;
     }
 }
+
+summary {
+    background-color: black;
+    color: white;
+    padding-top: 0.1em;
+    padding-bottom: 0.1em;
+    padding-left: 1cm;
+}


### PR DESCRIPTION
Can be used as such:

```
{% details Syllabus %}

The seminar covers:

* A
* B
* C

{% enddetails %}
```